### PR TITLE
Add voice input for web using Web Speech API

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,8 +1,15 @@
 import { useState } from 'react';
-import { Button, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Button, Platform, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useVoiceInput } from '@/hooks/useVoiceInput';
 
 export default function App() {
   const [input, setInput] = useState('');
+
+  const handleVoiceResult = (text) => {
+    setInput((prev) => (prev ? `${prev} ${text}` : text));
+  };
+
+  const { start, stop, listening, supported } = useVoiceInput(handleVoiceResult);
 
   const handleSubmit = () => {
     console.log('User Entry:', input);
@@ -22,6 +29,13 @@ export default function App() {
           value={input}
           onChangeText={setInput}
         />
+
+        {Platform.OS === 'web' && supported && (
+          <Button
+            title={listening ? 'Stop Recording' : 'Start Recording'}
+            onPress={listening ? stop : start}
+          />
+        )}
 
         <Button title="Submit Entry" onPress={handleSubmit} />
       </ScrollView>

--- a/hooks/useVoiceInput.ts
+++ b/hooks/useVoiceInput.ts
@@ -1,0 +1,8 @@
+export function useVoiceInput(_: (text: string) => void) {
+  return {
+    start: () => {},
+    stop: () => {},
+    listening: false,
+    supported: false,
+  };
+}

--- a/hooks/useVoiceInput.web.ts
+++ b/hooks/useVoiceInput.web.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useVoiceInput(onResult: (text: string) => void) {
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const [listening, setListening] = useState(false);
+  const [supported, setSupported] = useState(false);
+
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      setSupported(false);
+      return;
+    }
+    setSupported(true);
+    const recognition: SpeechRecognition = new SpeechRecognition();
+    recognition.lang = 'en-US';
+    recognition.interimResults = false;
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const transcript = Array.from(event.results)
+        .map((result) => result[0].transcript)
+        .join(' ');
+      onResult(transcript);
+    };
+    recognition.onerror = () => {
+      setListening(false);
+    };
+    recognition.onend = () => {
+      setListening(false);
+    };
+    recognitionRef.current = recognition;
+    return () => {
+      recognition.stop();
+    };
+  }, [onResult]);
+
+  const start = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (recognition && !listening) {
+      setListening(true);
+      recognition.start();
+    }
+  }, [listening]);
+
+  const stop = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (recognition && listening) {
+      recognition.stop();
+      setListening(false);
+    }
+  }, [listening]);
+
+  return {
+    start,
+    stop,
+    listening,
+    supported,
+  };
+}


### PR DESCRIPTION
## Summary
- add `useVoiceInput` hook with a web implementation
- show a Start/Stop Recording button on web
- append recognized speech to the text area

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c2f2fa6e0832b85baad3930e40760