### PR TITLE
Add Jest setup and basic HelloWave test

### DIFF
--- a/components/__tests__/HelloWave.test.tsx
+++ b/components/__tests__/HelloWave.test.tsx
@@ -1,0 +1,11 @@
+import Animated from 'react-native-reanimated';
+import { render } from '@testing-library/react-native';
+
+import { HelloWave } from '../HelloWave';
+
+describe('HelloWave', () => {
+  it('renders animated view', () => {
+    const { UNSAFE_getByType } = render(<HelloWave />);
+    expect(UNSAFE_getByType(Animated.View)).toBeTruthy();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -43,7 +44,12 @@
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "jest": "^29.7.0",
+    "jest-expo": "^53.0.0",
+    "@testing-library/react-native": "^13.1.0",
+    "@testing-library/jest-native": "^5.5.2",
+    "react-test-renderer": "19.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add Jest configuration with React Native Testing Library
- set npm test script
- add dev dependencies for Jest
- test HelloWave component rendering

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c229dcfc8832b83fd976d1548a853