### PR TITLE
Rename Explore Screen component

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -8,7 +8,7 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 
-export default function TabTwoScreen() {
+export default function ExploreScreen() {
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}


### PR DESCRIPTION
## Summary
- rename function in explore.tsx from TabTwoScreen to ExploreScreen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c2254e3e0832b9bf4518ba8fd7a65