### PR TITLE
Read API keys from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ npm install
 
 - Download your Firebase Admin SDK JSON file
 - Save it in the root folder
-- Add path to your `.env.local` (optional)
 
-4. Add your OpenAI API Key:
+4. Configure API keys:
 
-You can add this to your environment variables or insert directly in the code (not recommended for production).
+- Set the `FIREBASE_API_KEY` and `OPENAI_KEY` environment variables. You can create an `.env` file or export them in your shell before running the app.
 
 ---
 

--- a/utils/firebase.js
+++ b/utils/firebase.js
@@ -3,7 +3,7 @@ import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
+  apiKey: process.env.FIREBASE_API_KEY,
   authDomain: "your-project.firebaseapp.com",
   projectId: "your-project-id",
   storageBucket: "your-project.appspot.com",

--- a/utils/openai.js
+++ b/utils/openai.js
@@ -3,7 +3,7 @@ export async function getStructuredData(userInput) {
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
     headers: {
-      "Authorization": "Bearer YOUR_OPENAI_KEY",
+      "Authorization": `Bearer ${process.env.OPENAI_KEY}`,
       "Content-Type": "application/json"
     },
     body: JSON.stringify({


### PR DESCRIPTION
## Summary
- load OpenAI key from `process.env.OPENAI_KEY`
- load Firebase key from `process.env.FIREBASE_API_KEY`
- document required environment variables

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c3c069f24832baf6daf0aeb0313db