### PR TITLE
Improve journal submission error handling and logging

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,6 +16,7 @@ import { saveToFirebase } from '@/services/firestore';
 export default function HomeScreen() {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleVoiceResult = (text: string) => {
     setInput((prev) => (prev ? `${prev} ${text}` : text));
@@ -24,20 +25,31 @@ export default function HomeScreen() {
   const { start, stop, listening, supported } = useVoiceInput(handleVoiceResult);
 
   async function handleJournalSubmit(text: string) {
-    const structured = await fetchStructuredData(text);
-    await saveToFirebase(structured);
+    console.log('[Journal] Submitting text:', text);
+    try {
+      const structured = await fetchStructuredData(text);
+      console.log('[Journal] Structured result:', structured);
+      await saveToFirebase(structured);
+      console.log('[Journal] Saved to Firebase');
+    } catch (err) {
+      console.error('[Journal] Submission error:', err);
+      throw err;
+    }
   }
 
   const handleSubmit = async () => {
     if (!input.trim()) return;
 
     setLoading(true);
+    setError(null);
     try {
       await handleJournalSubmit(input);
       Alert.alert('Submitted!', 'Entry saved.');
       setInput('');
     } catch (error: any) {
-      Alert.alert('Error', error?.message ?? 'Something went wrong.');
+      const message = error?.message ?? 'Something went wrong.';
+      setError(message);
+      Alert.alert('Error', message);
     } finally {
       setLoading(false);
     }
@@ -65,6 +77,7 @@ export default function HomeScreen() {
           title={loading ? 'Submitting...' : 'Submit'}
           onPress={handleSubmit}
         />
+        {error && <Text style={styles.errorText}>{error}</Text>}
       </ScrollView>
     </View>
   );
@@ -98,5 +111,10 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginBottom: 20,
     textAlignVertical: 'top',
+  },
+  errorText: {
+    marginTop: 12,
+    color: 'red',
+    textAlign: 'center',
   },
 });

--- a/services/firestore.ts
+++ b/services/firestore.ts
@@ -6,9 +6,19 @@ const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
 export async function saveToFirebase(data: Record<string, unknown>) {
-  const now = new Date();
-  const dateStr = now.toISOString().split('T')[0];
-  const timeStr = now.toTimeString().split(' ')[0].replace(/:/g, '-');
-  const ref = doc(db, 'health_journal', dateStr, 'entries', timeStr);
-  await setDoc(ref, data);
+  try {
+    const now = new Date();
+    const dateStr = now.toISOString().split('T')[0];
+    const timeStr = now.toTimeString().split(' ')[0].replace(/:/g, '-');
+    const path = `health_journal/${dateStr}/entries/${timeStr}`;
+    console.log(`[Firestore] Saving to ${path}:`, data);
+
+    const ref = doc(db, 'health_journal', dateStr, 'entries', timeStr);
+    await setDoc(ref, data);
+
+    console.log('[Firestore] Saved successfully');
+  } catch (error) {
+    console.error('[Firestore] Error saving data:', error);
+    throw error;
+  }
 }

--- a/services/openai.ts
+++ b/services/openai.ts
@@ -1,21 +1,49 @@
 import Constants from 'expo-constants';
 
 export async function fetchStructuredData(prompt: string) {
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${Constants.manifest?.extra?.OPENAI_API_KEY}`,
-    },
-    body: JSON.stringify({
-      model: 'gpt-3.5-turbo',
-      temperature: 0.3,
-      messages: [
-        { role: 'system', content: 'Extract structured data as JSON...' },
-        { role: 'user', content: prompt },
-      ],
-    }),
-  });
-  const json = await res.json();
-  return JSON.parse(json.choices[0].message.content);
+  console.log('[OpenAI] Prompt:', prompt);
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${Constants.manifest?.extra?.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        temperature: 0.3,
+        messages: [
+          { role: 'system', content: 'Extract structured data as JSON...' },
+          { role: 'user', content: prompt },
+        ],
+      }),
+    });
+
+    const text = await res.text();
+    console.log('[OpenAI] Raw response:', text);
+
+    if (!res.ok) {
+      throw new Error(`OpenAI API error: ${res.status} ${res.statusText}`);
+    }
+
+    let json;
+    try {
+      json = JSON.parse(text);
+    } catch (err) {
+      console.error('[OpenAI] Failed to parse response JSON', err);
+      throw new Error('Invalid JSON response from OpenAI');
+    }
+
+    const content = json?.choices?.[0]?.message?.content;
+    console.log('[OpenAI] Message content:', content);
+
+    const data = JSON.parse(content);
+    console.log('[OpenAI] Structured data:', data);
+
+    return data;
+  } catch (error) {
+    console.error('[OpenAI] fetchStructuredData error:', error);
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary
- add detailed logging and error handling for OpenAI and Firestore services
- expose submission errors in the UI and console
- provide user feedback when saving fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892eaaa73a0832b921129f0805c6e79